### PR TITLE
Ensure synchronous source map generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "falafel": "0.3.1",
     "js-beautify": "*",
     "seq": "*",
-    "source-map": "*"
+    "source-map": "0.5.7"
   }
 }


### PR DESCRIPTION
Keep the `source-map` dependency at 0.5.6 to avoid receiving
promises instead of resolved `SourceMapConsumer` objects.