### PR TITLE
Pin version of `source-map`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "falafel": "0.3.1",
     "js-beautify": "*",
     "seq": "*",
-    "source-map": "*"
+    "source-map": "0.6.1"
   }
 }


### PR DESCRIPTION
Pin the version of `source-map` to the latest version that works
with the current code